### PR TITLE
test: Run CI with Ruby 4.0

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.4
+          ruby-version: '4.0'
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
       - name: Run haml-lint
         run: bundle exec haml-lint
@@ -33,7 +33,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.4
+          ruby-version: '4.0'
           bundler-cache: true
       - name: Run RuboCop
         run: bundle exec rubocop

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,16 +23,17 @@ jobs:
           - 3.2
           - 3.3
           - 3.4
+          - '4.0'
           - ruby-head
         active_support_version:
           - latest
         include:
-          - ruby: 3.4
-            active_support_version: ~> 7.0.x
-          - ruby: 3.4
+          - ruby: '4.0'
             active_support_version: ~> 7.1.x
-          - ruby: 3.4
+          - ruby: '4.0'
             active_support_version: ~> 7.2.x
+          - ruby: '4.0'
+            active_support_version: ~> 8.0.x
     env:
       ACTIVE_SUPPORT_VERSION: ${{ matrix.active_support_version }}
       RUBYOPT: ${{ matrix.ruby_version == 'ruby-head' && '-W:deprecated' || '' }}


### PR DESCRIPTION
- Add Ruby 4.0 to the CI matrix.
- Add Active Support 8.0 to the CI matrix.
- Remove Active Support 7.0 from the CI matrix.